### PR TITLE
Load Google Maps API key from config file

### DIFF
--- a/assets/js/geolocation.js
+++ b/assets/js/geolocation.js
@@ -148,14 +148,15 @@
     var callbacks = [];
     var loading = false;
 
-    // Obtain key from https://developers.google.com/maps/documentation/javascript/get-api-key
-    var apiKey = "";
-
-    if(apiKey === "") {
-      alert("[!] Please set a Google Maps API key in geolocation.js:152");
-    }
-
     function loadMaps() {
+
+      // Obtain key from https://developers.google.com/maps/documentation/javascript/get-api-key
+      var apiKey = document.querySelector('.geolocation-map').getAttribute('data-key');
+
+      if(apiKey === "" || apiKey === null) {
+        alert("[!] Please set a Google Maps API key in your config file.");
+      }
+      
       window._onGoogleMapsLoaded = function() {
         delete window._onGoogleMapsLoaded;
         callbacks.forEach(function(callback) {

--- a/geolocation.php
+++ b/geolocation.php
@@ -101,6 +101,7 @@ class GeolocationField extends InputField {
   public function elementWithClass($element, $class) {
     $element = new Brick($element);
     $element->addClass($class);
+    $element->data('key', c::get('geolocation-key', ''));
     return $element;
   }
 }


### PR DESCRIPTION
Hey, this change would make it so the Google Maps API key gets loaded from a config file rather than set directly in the JS file. This allows the plugin to be installed as a submodule without running into uncommitted changes issues.